### PR TITLE
status and amulet update

### DIFF
--- a/bigtop-packages/src/charm/hbase/layer-hbase/reactive/hbase.py
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/reactive/hbase.py
@@ -23,21 +23,21 @@ from charms.layer.hadoop_client import get_dist_config
 @when('bigtop.available')
 @when_not('zookeeper.joined')
 def waiting_for_zookeeper():
-    hookenv.status_set('blocked', 'Waiting for relation to Zookeeper')
+    hookenv.status_set('blocked', 'waiting for relation to zookeeper')
     remove_state('hbase.installed')
 
 
 @when('bigtop.available', 'zookeeper.joined')
 @when_not('zookeeper.ready')
 def waiting_for_zookeeper_ready(zk):
-    hookenv.status_set('waiting', 'Waiting for Zookeeper to become ready')
+    hookenv.status_set('waiting', 'waiting for zookeeper to become ready')
     remove_state('hbase.installed')
 
 
 @when('bigtop.available', 'zookeeper.ready')
 @when_not('hadoop.hdfs.ready')
 def waiting_for_hdfs(zk):
-    hookenv.status_set('waiting', 'Waiting for HDFS')
+    hookenv.status_set('waiting', 'waiting for hdfs')
     remove_state('hbase.installed')
 
 
@@ -47,7 +47,7 @@ def installing_hbase(zk, hdfs):
     if is_state('hbase.installed') and (not data_changed('zks', zks)):
         return
 
-    msg = "Configuring HBase" if is_state('hbase.installed') else "Installing HBase"
+    msg = "configuring hbase" if is_state('hbase.installed') else "installing hbase"
     hookenv.status_set('waiting', msg)
     distcfg = get_dist_config()
     hbase = HBase(distcfg)
@@ -57,7 +57,7 @@ def installing_hbase(zk, hdfs):
     hosts['namenode'] = nns[0]
     hbase.configure(hosts, zks)
     set_state('hbase.installed')
-    hookenv.status_set('active', 'Ready')
+    hookenv.status_set('active', 'ready')
 
 
 @when('hbase.installed', 'hbclient.joined')

--- a/bigtop-packages/src/charm/hbase/layer-hbase/tests/01-basic-deployment.py
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/tests/01-basic-deployment.py
@@ -30,7 +30,7 @@ class TestDeploy(unittest.TestCase):
         self.d.sentry.wait(timeout=1800)
 
     def test_deploy(self):
-        self.d.sentry.wait_for_messages({"hbase": "Waiting on relation to Java"})
+        self.d.sentry.wait_for_messages({"hbase": "waiting on relation to java"})
 
 
 if __name__ == '__main__':

--- a/bigtop-packages/src/charm/hbase/layer-hbase/tests/02-smoke-test.py
+++ b/bigtop-packages/src/charm/hbase/layer-hbase/tests/02-smoke-test.py
@@ -30,24 +30,24 @@ class TestDeploy(unittest.TestCase):
         self.d.add('namenode', 'hadoop-namenode')
         self.d.add('slave', 'hadoop-slave')
         self.d.add('plugin', 'hadoop-plugin')
-        self.d.add('jdk', 'openjdk')
+        self.d.add('openjdk', 'openjdk')
 
         self.d.relate('hbase:zookeeper', 'zk:zkclient')
         self.d.relate('plugin:hadoop-plugin', 'hbase:hadoop')
         self.d.relate('plugin:namenode', 'namenode:namenode')
         self.d.relate('slave:namenode', 'namenode:datanode')
 
-        self.d.relate('hbase:java', 'jdk:java')
-        self.d.relate('plugin:java', 'jdk:java')
-        self.d.relate('namenode:java', 'jdk:java')
-        self.d.relate('slave:java', 'jdk:java')
-        self.d.relate('zk:java', 'jdk:java')
+        self.d.relate('hbase:java', 'openjdk:java')
+        self.d.relate('plugin:java', 'openjdk:java')
+        self.d.relate('namenode:java', 'openjdk:java')
+        self.d.relate('slave:java', 'openjdk:java')
+        self.d.relate('zk:java', 'openjdk:java')
 
         self.d.setup(timeout=1800)
         self.d.sentry.wait(timeout=1800)
 
     def test_deploy(self):
-        self.d.sentry.wait_for_messages({"hbase": "Ready"})
+        self.d.sentry.wait_for_messages({"hbase": "ready"})
         hbase = self.d.sentry['hbase'][0]
         smk_uuid = hbase.action_do("smoke-test")
         output = self.d.get_action_output(smk_uuid)


### PR DESCRIPTION
- lowercase status
- update wait_for_messages to watch for appropriate message
- use `openjdk` instead of `jdk` in amulet test -- our base charms will already have `openjdk` deployed, and since our tests use `reset: false`, we can reuse that charm here. if we don't do this, we'll be deploying another openjdk charm named `jdk`.
