### PR TITLE
Kafka bind address puppet

### DIFF
--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -191,6 +191,7 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 #kafka
 kafka::server::port: "9092"
 kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
+kafka::server::bind_addr: ""
 
 zeppelin::server::spark_master_url: "yarn-client"
 zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"

--- a/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
+++ b/bigtop-deploy/puppet/hieradata/bigtop/cluster.yaml
@@ -191,7 +191,6 @@ hadoop::common::tez_jars: "/usr/lib/tez"
 #kafka
 kafka::server::port: "9092"
 kafka::server::zookeeper_connection_string: "%{hiera('bigtop::hadoop_head_node')}:2181"
-kafka::server::bind_addr: ""
 
 zeppelin::server::spark_master_url: "yarn-client"
 zeppelin::server::hiveserver2_url: "jdbc:hive2://%{hiera('hadoop-hive::common::hiveserver2_host')}:%{hiera('hadoop-hive::common::hiveserver2_port')}"

--- a/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
+++ b/bigtop-deploy/puppet/modules/kafka/manifests/init.pp
@@ -24,7 +24,8 @@ class kafka {
   class server(
       $broker_id = "0",
       $port = "9092",
-      $zookeeper_connection_string = "localhost:2181"
+      $zookeeper_connection_string = "localhost:2181",
+      $bind_addr = ""
     ) {
 
     package { 'kafka':

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -25,7 +25,7 @@ broker.id=<%= @broker_id %>
 port=<%= @port %>
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
-<% if @bind_addr %>
+<% if !@bind_addr.nil? && !@bind_addr.empty? %>
 host.name=<%= @bind_addr %>
 <% else %>
 #host.name=localhost

--- a/bigtop-deploy/puppet/modules/kafka/templates/server.properties
+++ b/bigtop-deploy/puppet/modules/kafka/templates/server.properties
@@ -25,7 +25,11 @@ broker.id=<%= @broker_id %>
 port=<%= @port %>
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
+<% if @bind_addr %>
+host.name=<%= @bind_addr %>
+<% else %>
 #host.name=localhost
+<% end %>
 
 # Hostname the broker will advertise to producers and consumers. If not set, it uses the
 # value for "host.name" if configured.  Otherwise, it will use the value returned from


### PR DESCRIPTION
@juju-solutions/bigdata 

This is one of three pull requests for setting up the ability to bind kafka to an interface/ip address. I've run bundletester with the following permutations of 'bind_addr' in config.yaml:

1) Keeping the default value of null doesn't break anything, which is expected.
2) Passing in a value of 0.0.0.0 doesn't break anything, which is expected.
3) Passing in an address that doesn't match the address of the kafka server (e.g., 10.0.9.9) does break things.

My juju fu is not strong enough to setup a second interface on a machine and bind to that, but the above three tests do seem to indicate that the code does what I think that it does.

As part of this work, I also fixed up the kafka tests. It should be easy to get them to run, even if you aren't paying attention to anything other than having the right branch of layer-apache-bigtop-base checked out locally. (The branch is 'kafka-bind-address', incidentally)
