### PR TITLE
Kafka bind address fixed

### DIFF
--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,0 +1,7 @@
+options:
+  bind_addr:
+    default: 0.0.0.0
+    type: string
+    description: |
+      IP address of the interface to listen on, if something other than the
+      default is desired.

--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,6 +1,6 @@
 options:
   bind_addr:
-    default: 0.0.0.0
+    default: null
     type: string
     description: |
       IP address of the interface to listen on, if something other than the

--- a/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
@@ -55,6 +55,9 @@ class Kafka(object):
             'kafka::server::port': kafka_port,
             'kafka::server::zookeeper_connection_string': zk_connect,
         }
+        bind_addr = hookenv.config().get('bind_addr')
+        if bind_addr:
+            override['kafka::server::bind_addr'] = bind_addr
 
         bigtop = Bigtop()
         bigtop.render_site_yaml(roles=roles, overrides=override)

--- a/bigtop-packages/src/charm/kafka/layer-kafka/tests/01-deploy.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/tests/01-deploy.py
@@ -33,12 +33,7 @@ class TestDeploy(unittest.TestCase):
         cls.d.configure('openjdk', {'java-type': 'jdk',
                                     'java-major': '8'})
 
-        try:
-            cls.d.relate('kafka:zookeeper', 'zk:zkclient')
-        except ValueError:
-            # Depending on the zookeeper we're deploying, it may or
-            # may not support the zkclient relation.
-            cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
+        cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
         cls.d.relate('kafka:java', 'openjdk:java')
         try:
             cls.d.relate('zk:java', 'openjdk:java')

--- a/bigtop-packages/src/charm/kafka/layer-kafka/tests/01-deploy.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/tests/01-deploy.py
@@ -33,9 +33,19 @@ class TestDeploy(unittest.TestCase):
         cls.d.configure('openjdk', {'java-type': 'jdk',
                                     'java-major': '8'})
 
-        cls.d.relate('kafka:zookeeper', 'zk:zkclient')
+        try:
+            cls.d.relate('kafka:zookeeper', 'zk:zkclient')
+        except ValueError:
+            # Depending on the zookeeper we're deploying, it may or
+            # may not support the zkclient relation.
+            cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
         cls.d.relate('kafka:java', 'openjdk:java')
-        cls.d.relate('zk:java', 'openjdk:java')
+        try:
+            cls.d.relate('zk:java', 'openjdk:java')
+        except ValueError:
+            # No need to related older versions of the zookeeper charm
+            # to java.
+            pass
 
         cls.d.setup(timeout=900)
         cls.d.sentry.wait_for_messages({'kafka': 'ready'}, timeout=1800)
@@ -45,7 +55,7 @@ class TestDeploy(unittest.TestCase):
         """
         Simple test to make sure the Kafka java process is running.
         """
-        output, retcode = self.unit.run("pgrep -a java")
+        output, retcode = self.kafka.run("pgrep -a java")
         assert 'Kafka' in output, "Kafka daemon is not started"
 
 

--- a/bigtop-packages/src/charm/kafka/layer-kafka/tests/02-smoke-test.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/tests/02-smoke-test.py
@@ -33,12 +33,7 @@ class TestDeploy(unittest.TestCase):
         cls.d.configure('openjdk', {'java-type': 'jdk',
                                     'java-major': '8'})
 
-        try:
-            cls.d.relate('kafka:zookeeper', 'zk:zkclient')
-        except ValueError:
-            # Depending on the zookeeper we're deploying, it may or
-            # may not support the zkclient relation.
-            cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
+        cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
         cls.d.relate('kafka:java', 'openjdk:java')
         try:
             cls.d.relate('zk:java', 'openjdk:java')

--- a/bigtop-packages/src/charm/kafka/layer-kafka/tests/02-smoke-test.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/tests/02-smoke-test.py
@@ -33,9 +33,19 @@ class TestDeploy(unittest.TestCase):
         cls.d.configure('openjdk', {'java-type': 'jdk',
                                     'java-major': '8'})
 
-        cls.d.relate('kafka:zookeeper', 'zk:zkclient')
+        try:
+            cls.d.relate('kafka:zookeeper', 'zk:zkclient')
+        except ValueError:
+            # Depending on the zookeeper we're deploying, it may or
+            # may not support the zkclient relation.
+            cls.d.relate('kafka:zookeeper', 'zk:zookeeper')
         cls.d.relate('kafka:java', 'openjdk:java')
-        cls.d.relate('zk:java', 'openjdk:java')
+        try:
+            cls.d.relate('zk:java', 'openjdk:java')
+        except ValueError:
+            # No need to related older versions of the zookeeper charm
+            # to java.
+            pass
 
         cls.d.setup(timeout=900)
         cls.d.sentry.wait_for_messages({'kafka': 'ready'}, timeout=1800)


### PR DESCRIPTION
@juju-solutions/bigdata 

This is one of three pull requests for setting up the ability to bind kafka to an interface/ip address. I've run bundletester with the following permutations of 'bind_addr' in config.yaml:

1) Keeping the default value of null doesn't break anything, which is expected.
2) Passing in a value of 0.0.0.0 doesn't break anything, which is expected.
3) Passing in an address that doesn't match the address of the kafka server (e.g., 10.0.9.9) does break things.

My juju fu is not strong enough to setup a second interface on a machine and bind to that, but the above three tests do seem to indicate that the code does what I think that it does.

As part of this work, I also fixed up the kafka tests. It should be easy to get them to run, even if you aren't paying attention to anything other than having the right branch of layer-apache-bigtop-base checked out locally. (The branch is 'kafka-bind-address', incidentally)
