### PR TITLE
Zookeeper bind address

### DIFF
--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
@@ -1,7 +1,7 @@
 options:
-  client_port_bind_address:
+  client_bind_addr:
     default: null
     type: string
     description: |
-      IP address of the interface to listen on, if something other than the
-      default is desired.
+      IP address of the interface to listen for clients on, if something
+      other than the default is desired.

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
@@ -1,6 +1,6 @@
 options:
   client_bind_addr:
-    default: null
+    default: ""
     type: string
     description: |
       IP address of the interface to listen for clients on, if something

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
@@ -1,0 +1,7 @@
+options:
+  client_port_bind_address:
+    default: null
+    type: string
+    description: |
+      IP address of the interface to listen on, if something other than the
+      default is desired.

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
@@ -103,9 +103,9 @@ class Zookeeper(object):
             "hadoop_zookeeper::server::myid": local_unit().split("/")[1],
             "hadoop_zookeeper::server::ensemble": self.read_peers()
         }
-        bind_addr = config().get('client_port_bind_address')
+        bind_addr = config().get('client_bind_addr')
         if bind_addr:
-            key = "hadoop_zookeeper::server::client_port_bind_address"
+            key = "hadoop_zookeeper::server::client_bind_addr"
             override[key] = bind_addr
 
         return override

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
@@ -17,7 +17,7 @@ import subprocess
 
 from charmhelpers.core import host
 from charmhelpers.core.hookenv import (open_port, close_port, log,
-                                       unit_private_ip, local_unit)
+                                       unit_private_ip, local_unit, config)
 from charms import layer
 from charms.layer.apache_bigtop_base import Bigtop
 from charms.reactive.relations import RelationBase
@@ -103,6 +103,10 @@ class Zookeeper(object):
             "hadoop_zookeeper::server::myid": local_unit().split("/")[1],
             "hadoop_zookeeper::server::ensemble": self.read_peers()
         }
+        bind_addr = config().get('client_port_bind_address')
+        if bind_addr:
+            key = "hadoop_zookeeper::server::client_port_bind_address"
+            override[key] = bind_addr
 
         return override
 

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
@@ -1,4 +1,5 @@
 name: zookeeper
+series: [xenial]
 maintainer: Juju Big Data <bigdata@lists.ubuntu.com>
 summary: High-performance coordination service for distributed applications
 description: |

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/metadata.yaml
@@ -10,7 +10,7 @@ description: |
   components, you must start the ZooKeeper service.
 tags: ["bigdata", "hadoop", "apache"]
 provides:
-  zkclient:
+  zookeeper:
     interface: zookeeper
 peers:
   zkpeer:

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/reactive/zookeeper.py
@@ -59,7 +59,7 @@ def check_cluster():
         hookenv.status_set('active', message)
 
 
-@when('zookeeper.started', 'zkclient.joined')
+@when('zookeeper.started', 'zookeeper.joined')
 def serve_client(client):
     config = Zookeeper().dist_config
     port = config.port('zookeeper')

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/tests/01-deploy
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/tests/01-deploy
@@ -26,7 +26,7 @@ class TestDeploy(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.d = amulet.Deployment(series='trusty')
+        cls.d = amulet.Deployment(series='xenial')
 
         cls.d.add('jdk', charm='openjdk')
         cls.d.add('zookeeper', charm='zookeeper', units=3)


### PR DESCRIPTION
These are fixes to Zookeeper, which do two things:

1) Allow an operator to restrict the interface/ip that the client listens on, in secure environments.
2) Sets the series to xenial, so that we can promulgate to the store without clobbering things.

This is the first PR in a chain of three. The next PR is against upstream master, and implements puppet fixes to support our changes: https://github.com/apache/bigtop/pull/135/files

The last PR in the chain is the patch to the bigtop base layer, which also contains a fix for installing the bigtop zookeeper deb on xenial: https://github.com/juju-solutions/layer-apache-bigtop-base/pull/33
