### PR TITLE
Fix for issues with Zookeeper client_bind_addr option.

### DIFF
--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/config.yaml
@@ -1,7 +1,10 @@
 options:
-  client_bind_addr:
+  network_interface:
     default: ""
     type: string
     description: |
-      IP address of the interface to listen for clients on, if something
-      other than the default is desired.
+      Network interface to bind the Zookeeper client port to. Defaults
+      to accepting connections on all interfaces. Accepts either the
+      name of an interface (e.g., 'eth0'), or a CIDR range. If the
+      latter, we\'ll bind to the first interface that we find with an
+      IP address in that range.

--- a/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
+++ b/bigtop-packages/src/charm/zookeeper/layer-zookeeper/lib/charms/layer/zookeeper.py
@@ -103,10 +103,10 @@ class Zookeeper(object):
             "hadoop_zookeeper::server::myid": local_unit().split("/")[1],
             "hadoop_zookeeper::server::ensemble": self.read_peers()
         }
-        bind_addr = config().get('client_bind_addr')
-        if bind_addr:
+        network_interface = config().get('network_interface')
+        if network_interface:
             key = "hadoop_zookeeper::server::client_bind_addr"
-            override[key] = bind_addr
+            override[key] = Bigtop().get_ip_for_interface(network_interface)
 
         return override
 


### PR DESCRIPTION
@juju-solutions/bigdata 

Since this value was set at config time, the config would be duplicated
across instances of the charm, instead of being unique to each machine,
as an ip address should be.

This, coupled with matching code change in the bigtop base layer, fixes
the issue, and also fixes an issue where Zookeeper would not restart if
you changed its interface after deploying it.
