### PR TITLE
Fixed up bind address for kafka.

### DIFF
--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,7 +1,10 @@
 options:
-  bind_addr:
-    default: null
+  network_interface:
+    default: ""
     type: string
     description: |
-      IP address of the interface to listen on, if something other than the
-      default is desired.
+      Network interface to bind Kafka to. Defaults to accepting
+      connections on all interfaces. Accepts either the name of an
+      interface (e.g., 'eth0'), or a CIDR range. If the latter, we\'ll
+      bind to the first interface that we find with an IP address in
+      that range.

--- a/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/lib/charms/layer/bigtop_kafka.py
@@ -55,9 +55,10 @@ class Kafka(object):
             'kafka::server::port': kafka_port,
             'kafka::server::zookeeper_connection_string': zk_connect,
         }
-        bind_addr = hookenv.config().get('bind_addr')
-        if bind_addr:
-            override['kafka::server::bind_addr'] = bind_addr
+        network_interface = hookenv.config().get('network_interface')
+        if network_interface:
+            ip = Bigtop().get_ip_for_interface(network_interface)
+            override['kafka::server::bind_addr'] = ip
 
         bigtop = Bigtop()
         bigtop.render_site_yaml(roles=roles, overrides=override)


### PR DESCRIPTION
Changed name to "network_interface". You may now pass an interface name
or a CIDR range, and juju will figure out the correct ip address to drop
into the server.properties config.

@juju-solutions/bigdata 
